### PR TITLE
ci: fix long CI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,7 +8,7 @@ jobs:
   check:
     name: 🧹 Lint & format
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 8
     defaults:
       run:
         shell: bash
@@ -23,6 +23,18 @@ jobs:
         uses: moonrepo/setup-toolchain@v0
         with:
           auto-install: true
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "pnpm_cache_dir=$(pnpm store path)" >> ${GITHUB_OUTPUT}
+
+      - uses: actions/cache@v4
+        name: Setup pnpm cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
 
       - name: Lint & format
         run: moon ci :check --color

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,7 +25,10 @@ jobs:
           auto-install: true
 
       - name: Lint & format
-        run: moon ci :check
+        run: moon ci :check --color
         env:
           # disable Chrome download on puppeteer install. see https://pptr.dev/api/puppeteer.configuration
           PUPPETEER_SKIP_CHROME_DOWNLOAD: true
+      
+      - uses: appthrust/moon-ci-retrospect@v1
+        if: success() || failure()

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
     outputs:
       # Output the artifact upload id
       artifact-upload-id: ${{ steps.artifact-upload-step.outputs.artifact-id }}
-    timeout-minutes: 5
+    timeout-minutes: 8
     defaults:
       run:
         shell: bash
@@ -32,6 +32,18 @@ jobs:
         uses: moonrepo/setup-toolchain@v0
         with:
           auto-install: true
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "pnpm_cache_dir=$(pnpm store path)" >> ${GITHUB_OUTPUT}
+
+      - uses: actions/cache@v4
+        name: Setup pnpm cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
 
       - name: Run tests
         if: ${{ matrix.node_version != '18' }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,14 +35,17 @@ jobs:
 
       - name: Run tests
         if: ${{ matrix.node_version != '18' }}
-        run: moon ci :test
+        run: moon ci :test --color
 
-      - name: Run tests and generate coverage reports
+      - name: Run tests & generate coverage reports
         if: ${{ matrix.node_version == '18' }}
-        run: moon ci :coverage
+        run: moon ci :coverage --color
         env:
           # disable Chrome download on puppeteer install. see https://pptr.dev/api/puppeteer.configuration
           PUPPETEER_SKIP_CHROME_DOWNLOAD: true
+      
+      - uses: appthrust/moon-ci-retrospect@v1
+        if: success() || failure()
 
       - name: Archive code coverage reports
         if: ${{ matrix.node_version == '18' }}

--- a/packages/greenit/src/api/__mocks__/Client.ts
+++ b/packages/greenit/src/api/__mocks__/Client.ts
@@ -1,0 +1,20 @@
+import type { GreenITConfig, GreenITReport } from "@scodi/common";
+
+export async function requestResult(
+	_conf: GreenITConfig,
+): Promise<GreenITReport["result"]> {
+	return {
+		url: "https://www.ipcc.ch/",
+		success: true,
+		nbBestPracticesToCorrect: 13,
+		grade: "E",
+		ecoIndex: 28,
+		pageInformations: {
+			url: "https://www.ipcc.ch",
+		},
+		date: "09/02/2023 23:32:57",
+		tryNb: 1,
+		tabId: 0,
+		index: 0,
+	} as unknown as GreenITReport["result"];
+}

--- a/packages/greenit/tests/GreenITModule.test.ts
+++ b/packages/greenit/tests/GreenITModule.test.ts
@@ -5,6 +5,7 @@ import { GreenITModule } from "../src/GreenITModule.js";
 import { Conf } from "./data/Conf.js";
 import SuccessResult from "./data/SuccessResult.json" with { type: "json" };
 
+vi.mock("../src/api/Client.js");
 vi.mock("greenit-cli/cli-core/analysis.js");
 const mockedCreateJsonReports = vi.mocked(createJsonReports);
 


### PR DESCRIPTION
# Changelog

- added CI debug : color + [appthrust/moon-ci-retrospect](https://github.com/appthrust/moon-ci-retrospect) action, as written in [Continuous integration (CI) > Community offerings](https://moonrepo.dev/docs/guides/ci#community-offerings)
- increased jobs timeout to 8 min (instead of 5) for jobs installing dependencies (lint and test)
- added cache for pnpm, using [Cache action](https://github.com/actions/cache)
- fixed GreenIT client not mocked in tests (which required Chrome to be installed)