### PR TITLE
ci: fix coverage taking into account js files

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,20 @@ export default defineConfig({
     test: {
         coverage: {
             provider: 'v8',
-            reporter: ['clover'],
+            reporter: ['clover', 'html'],
+            exclude: [
+                'vitest.config.ts',
+                'vitest.workspace.ts',
+                'coverage/**',
+                'packages/*/tests/**',
+                'templates/**',
+                '**/__mocks__/**',
+                '**/lib/**',
+                '**/node_modules/**',
+                '**/[.]**',
+                '**/*.d.ts',
+                '**/*.test.ts',
+            ]
         },
         environment: 'node',
     },


### PR DESCRIPTION
# Changelog

Remove the following directories and files from coverage calculation:

- [x] lib/ directories (packages build output)
- [x] templates/ directory
- [x] packages/*/tests directory
- [x] \_\_mocks\_\_ directories