### PR TITLE
chore: sync packages dependencies

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -31,14 +31,14 @@
   },
   "dependencies": {
     "@scodi/common": "workspace:^4.0.0",
-    "@fastify/cors": "^9.0.0",
-    "ajv": "^8.12.0",
-    "ajv-errors": "^3.0.0",
-    "fastify": "^4.25.2"
+    "@fastify/cors": "catalog:",
+    "ajv": "catalog:",
+    "ajv-errors": "catalog:",
+    "fastify": "catalog:"
   },
   "devDependencies": {
-    "@types/express": "^4.17.21",
-    "@types/node": "^18.19.6"
+    "@types/express": "catalog:",
+    "@types/node": "catalog:"
   },
   "peerDependencies": {
     "@scodi/cli": "workspace:^4.0.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,18 +33,18 @@
   },
   "dependencies": {
     "@scodi/common": "workspace:^4.0.0",
-    "ajv": "^8.12.0",
-    "ajv-errors": "^3.0.0",
-    "ajv-formats": "^3.0.0",
-    "commander": "^12.0.0",
-    "dotenv": "^16.3.1",
-    "ora": "^8.0.1"
+    "ajv": "catalog:",
+    "ajv-errors": "catalog:",
+    "ajv-formats": "catalog:",
+    "commander": "catalog:",
+    "dotenv": "catalog:",
+    "ora": "catalog:"
   },
   "devDependencies": {
-    "@fastify/cors": "^9.0.0",
-    "@types/node": "^18.19.6",
-    "fastify": "^4.25.2",
-    "type-fest": "^4.9.0"
+    "@fastify/cors": "catalog:",
+    "@types/node": "catalog:",
+    "fastify": "catalog:",
+    "type-fest": "catalog:"
   },
   "engines": {
     "node": "^18.20.0 || ^19.0.0 || ^20.16.0 || ^21.0.0 || ^22.0.0"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -28,20 +28,20 @@
     "prepublishOnly": "moon run common:build"
   },
   "dependencies": {
-    "@mikro-orm/core": "^6.0.0",
-    "@mikro-orm/reflection": "^6.0.0",
-    "ajv": "^8.12.0",
-    "ajv-errors": "^3.0.0",
-    "pino": "^9.0.0",
-    "pino-pretty": "^11.0.0"
+    "@mikro-orm/core": "catalog:",
+    "@mikro-orm/reflection": "catalog:",
+    "ajv": "catalog:",
+    "ajv-errors": "catalog:",
+    "pino": "catalog:",
+    "pino-pretty": "catalog:"
   },
   "devDependencies": {
-    "@fastify/cors": "^9.0.0",
-    "@types/har-format": "^1.2.15",
-    "@types/node": "^18.19.6",
-    "fastify": "^4.25.2",
-    "lighthouse": "^11.4.0",
-    "type-fest": "^4.9.0"
+    "@fastify/cors": "catalog:",
+    "@types/har-format": "catalog:",
+    "@types/node": "catalog:",
+    "fastify": "catalog:",
+    "lighthouse": "catalog:",
+    "type-fest": "catalog:"
   },
   "engines": {
     "node": "^18.20.0 || ^19.0.0 || ^20.16.0 || ^21.0.0 || ^22.0.0"

--- a/packages/greenit/package.json
+++ b/packages/greenit/package.json
@@ -39,10 +39,10 @@
   "dependencies": {
     "@scodi/common": "workspace:^4.0.0",
     "greenit-cli": "git+ssh://git@github.com:cnumr/GreenIT-Analysis-cli.git#9c1f010ad939782fab6fa1033d0ac267da547760",
-    "puppeteer": "^23.0.0"
+    "puppeteer": "catalog:"
   },
   "devDependencies": {
-    "@types/node": "^18.19.6"
+    "@types/node": "catalog:"
   },
   "peerDependencies": {
     "@scodi/cli": "workspace:^4.0.0"

--- a/packages/lighthouse/package.json
+++ b/packages/lighthouse/package.json
@@ -32,11 +32,11 @@
   },
   "dependencies": {
     "@scodi/common": "workspace:^4.0.0",
-    "lighthouse": "^11.4.0",
-    "puppeteer": "^23.0.0"
+    "lighthouse": "catalog:",
+    "puppeteer": "catalog:"
   },
   "devDependencies": {
-    "@types/node": "^18.19.6"
+    "@types/node": "catalog:"
   },
   "peerDependencies": {
     "@scodi/cli": "workspace:^4.0.0"

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -31,14 +31,14 @@
   },
   "dependencies": {
     "@scodi/common": "workspace:^4.0.0",
-    "@mikro-orm/core": "^6.0.0",
-    "@mikro-orm/migrations": "^6.0.0",
-    "@mikro-orm/mysql": "^6.0.0"
+    "@mikro-orm/core": "catalog:",
+    "@mikro-orm/migrations": "catalog:",
+    "@mikro-orm/mysql": "catalog:"
   },
   "devDependencies": {
-    "@mikro-orm/cli": "^6.0.0",
-    "@types/node": "^18.19.6",
-    "ts-node": "^10.9.1"
+    "@mikro-orm/cli": "catalog:",
+    "@types/node": "catalog:",
+    "ts-node": "catalog:"
   },
   "peerDependencies": {
     "@scodi/cli": "workspace:^4.0.0"

--- a/packages/observatory/package.json
+++ b/packages/observatory/package.json
@@ -33,7 +33,7 @@
     "@scodi/common": "workspace:^4.0.0"
   },
   "devDependencies": {
-    "@types/node": "^18.19.6"
+    "@types/node": "catalog:"
   },
   "peerDependencies": {
     "@scodi/cli": "workspace:^4.0.0"

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -31,10 +31,10 @@
   },
   "dependencies": {
     "@scodi/common": "workspace:^4.0.0",
-    "@slack/web-api": "^7.0.0"
+    "@slack/web-api": "catalog:"
   },
   "devDependencies": {
-    "@types/node": "^18.19.6"
+    "@types/node": "catalog:"
   },
   "peerDependencies": {
     "@scodi/cli": "workspace:^4.0.0"

--- a/packages/ssllabs-server/package.json
+++ b/packages/ssllabs-server/package.json
@@ -33,7 +33,7 @@
     "@scodi/common": "workspace:^4.0.0"
   },
   "devDependencies": {
-    "@types/node": "^18.19.6"
+    "@types/node": "catalog:"
   },
   "peerDependencies": {
     "@scodi/cli": "workspace:^4.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,54 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    '@mikro-orm/cli':
+      specifier: ^6.0.0
+      version: 6.3.5
+    '@mikro-orm/migrations':
+      specifier: ^6.0.0
+      version: 6.3.5
+    '@mikro-orm/mysql':
+      specifier: ^6.0.0
+      version: 6.3.5
+    '@mikro-orm/reflection':
+      specifier: ^6.0.0
+      version: 6.3.5
+    '@slack/web-api':
+      specifier: ^7.0.0
+      version: 7.3.2
+    '@types/express':
+      specifier: ^4.17.21
+      version: 4.17.21
+    '@types/har-format':
+      specifier: ^1.2.15
+      version: 1.2.15
+    ajv-errors:
+      specifier: ^3.0.0
+      version: 3.0.0
+    ajv-formats:
+      specifier: ^3.0.0
+      version: 3.0.1
+    commander:
+      specifier: ^12.0.0
+      version: 12.1.0
+    dotenv:
+      specifier: ^16.3.1
+      version: 16.4.5
+    ora:
+      specifier: ^8.0.1
+      version: 8.0.1
+    pino:
+      specifier: ^9.0.0
+      version: 9.3.2
+    pino-pretty:
+      specifier: ^11.0.0
+      version: 11.2.2
+    ts-node:
+      specifier: ^10.9.1
+      version: 10.9.2
+
 overrides:
   '@fastify/cors': ^9.0.0
   '@mikro-orm/core': ^6.0.0
@@ -58,14 +106,14 @@ importers:
         specifier: ^8.12.0
         version: 8.17.1
       ajv-errors:
-        specifier: ^3.0.0
+        specifier: 'catalog:'
         version: 3.0.0(ajv@8.17.1)
       fastify:
         specifier: ^4.25.2
         version: 4.28.1
     devDependencies:
       '@types/express':
-        specifier: ^4.17.21
+        specifier: 'catalog:'
         version: 4.17.21
       '@types/node':
         specifier: ^18.19.6
@@ -80,19 +128,19 @@ importers:
         specifier: ^8.12.0
         version: 8.17.1
       ajv-errors:
-        specifier: ^3.0.0
+        specifier: 'catalog:'
         version: 3.0.0(ajv@8.17.1)
       ajv-formats:
-        specifier: ^3.0.0
+        specifier: 'catalog:'
         version: 3.0.1(ajv@8.17.1)
       commander:
-        specifier: ^12.0.0
+        specifier: 'catalog:'
         version: 12.1.0
       dotenv:
-        specifier: ^16.3.1
+        specifier: 'catalog:'
         version: 16.4.5
       ora:
-        specifier: ^8.0.1
+        specifier: 'catalog:'
         version: 8.0.1
     devDependencies:
       '@fastify/cors':
@@ -114,26 +162,26 @@ importers:
         specifier: ^6.0.0
         version: 6.3.5
       '@mikro-orm/reflection':
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.3.5(@mikro-orm/core@6.3.5)
       ajv:
         specifier: ^8.12.0
         version: 8.17.1
       ajv-errors:
-        specifier: ^3.0.0
+        specifier: 'catalog:'
         version: 3.0.0(ajv@8.17.1)
       pino:
-        specifier: ^9.0.0
+        specifier: 'catalog:'
         version: 9.3.2
       pino-pretty:
-        specifier: ^11.0.0
+        specifier: 'catalog:'
         version: 11.2.2
     devDependencies:
       '@fastify/cors':
         specifier: ^9.0.0
         version: 9.0.1
       '@types/har-format':
-        specifier: ^1.2.15
+        specifier: 'catalog:'
         version: 1.2.15
       '@types/node':
         specifier: ^18.19.6
@@ -192,10 +240,10 @@ importers:
         specifier: ^6.0.0
         version: 6.3.5
       '@mikro-orm/migrations':
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.3.5(@mikro-orm/core@6.3.5)(@types/node@18.19.44)
       '@mikro-orm/mysql':
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.3.5(@mikro-orm/core@6.3.5)
       '@scodi/cli':
         specifier: workspace:^4.0.0
@@ -205,13 +253,13 @@ importers:
         version: link:../common
     devDependencies:
       '@mikro-orm/cli':
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.3.5
       '@types/node':
         specifier: ^18.19.6
         version: 18.19.44
       ts-node:
-        specifier: ^10.9.1
+        specifier: 'catalog:'
         version: 10.9.2(@types/node@18.19.44)(typescript@5.5.4)
 
   packages/observatory:
@@ -236,7 +284,7 @@ importers:
         specifier: workspace:^4.0.0
         version: link:../common
       '@slack/web-api':
-        specifier: ^7.0.0
+        specifier: 'catalog:'
         version: 7.3.2
     devDependencies:
       '@types/node':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,27 @@
 packages:
-  - 'packages/*'
-  - 'test/'
+  - packages/*
+  - test/
+catalog:
+  "@fastify/cors": ^9.0.0
+  "@mikro-orm/cli": ^6.0.0
+  "@mikro-orm/core": ^6.0.0
+  "@mikro-orm/migrations": ^6.0.0
+  "@mikro-orm/mysql": ^6.0.0
+  "@mikro-orm/reflection": ^6.0.0
+  "@slack/web-api": ^7.0.0
+  "@types/express": ^4.17.21
+  "@types/har-format": ^1.2.15
+  "@types/node": ^18.19.6
+  ajv: ^8.12.0
+  ajv-errors: ^3.0.0
+  ajv-formats: ^3.0.0
+  commander: ^12.0.0
+  dotenv: ^16.3.1
+  fastify: ^4.25.2
+  lighthouse: ^11.4.0
+  ora: ^8.0.1
+  pino: ^9.0.0
+  pino-pretty: ^11.0.0
+  puppeteer: ^23.0.0
+  ts-node: ^10.9.1
+  type-fest: ^4.9.0


### PR DESCRIPTION
# Changelog

- sync packages dependencies

Note: it is required to use the `pnpm pack` command before publishing to JSR, becasue this command (and `pnpm publish`) replaces the `workspace:` and `catalog:` keywords in package.json files

Closes #57 