### PR TITLE
ci: change the SonarQube GitHub action

### DIFF
--- a/.github/workflows/analysis.yaml
+++ b/.github/workflows/analysis.yaml
@@ -48,6 +48,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          # Disabling shallow clones is recommended for improving the relevancy of SonarQube reporting
           fetch-depth: 0
 
       - name: Set Node.js version
@@ -77,7 +78,7 @@ jobs:
       - name: Generate coverage report
         run: moon run ${{ matrix.projects.id }}:coverage
 
-      - uses: SonarSource/sonarcloud-github-action@v3
+      - uses: sonarsource/sonarqube-scan-action@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/analysis.yaml
+++ b/.github/workflows/analysis.yaml
@@ -24,6 +24,9 @@ jobs:
         with:
           auto-install: true
 
+      # Guess projects that have been changed:
+      # - for Pull Requests, guess from changed files only
+      # - for other cases, guess from all files
       - name: Guess projects
         id: moon-query
         run: |
@@ -38,6 +41,11 @@ jobs:
     name: Code coverage
     runs-on: ubuntu-latest
     needs: list-projects
+    # Do not run this job if no project have been changed
+    # Note: GitHub performs loose equality comparisons; env.PROJECTS is an array, so GitHub GitHub coerces the type to NaN.
+    # And when NaN is one of the operands of any relational comparison (>, <, >=, <=), the result is always false.
+    # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#operators
+    if: ${{ toJSON(fromJSON(needs.list-projects.outputs.list).projects) != '[]' }}
     strategy:
       matrix:
         projects: ${{ fromJSON(needs.list-projects.outputs.list).projects }}


### PR DESCRIPTION
# Changelog

- [ci] replace the SonarQube action by [the new official one ](https://github.com/marketplace/actions/official-sonarqube-scan)
- [ci] don't execute the SonarQube analysis if no project files was changed